### PR TITLE
Bad attributes strip

### DIFF
--- a/xmlParser.js
+++ b/xmlParser.js
@@ -18,7 +18,7 @@ function XMLParser() {
     }
     
     function parseTag(tagText, parent) {
-        tagText = tagText.replace('<', '').replace('>', '').split(' ');
+        tagText = tagText.match(/([^\s]*)=["'](.*?)["']|([\w\-]+)/g);
         
         var tag = {
             name: tagText[0],

--- a/xmlParser.js
+++ b/xmlParser.js
@@ -18,7 +18,7 @@ function XMLParser() {
     }
     
     function parseTag(tagText, parent) {
-        tagText = tagText.match(/([^\s]*)=["'](.*?)["']|([\w\-]+)/g);
+        tagText = tagText.match(/([^\s]*)=["'](.*?)["']|([\/?\w\-]+)/g);
         
         var tag = {
             name: tagText[0],


### PR DESCRIPTION
If some attribute has spaces in it value then parseTag function fails.