### PR TITLE
add: Allow quotes in attributes

### DIFF
--- a/xmlParser.js
+++ b/xmlParser.js
@@ -4,14 +4,14 @@ module.exports = class {
     _parseFromString(xmlText) {
         var cleanXmlText = xmlText.replace(/\s{2,}/g, ' ').replace(/\\t\\n\\r/g, '').replace(/>/g, '>\n');
         var rawXmlData = [];
-        
+
         cleanXmlText.split('\n').map(element => {
             element = element.trim();
 
             if (!element || element.indexOf('?xml') > -1) {
                 return;
             }
-            
+
             if (element.indexOf('<') == 0 && element.indexOf('CDATA') < 0) {
                 var parsedTag = this._parseTag(element);
 
@@ -31,7 +31,7 @@ module.exports = class {
 
     _getElementsByTagName(tagName) {
         var matches = [];
-        
+
         if (tagName == '*' || this.name.toLowerCase() === tagName.toLowerCase()) {
             matches.push(this);
         }
@@ -39,12 +39,12 @@ module.exports = class {
         this.children.map(child => {
             matches = matches.concat(child.getElementsByTagName(tagName));
         });
-        
+
         return matches;
     }
-    
+
     _parseTag(tagText, parent) {
-        var cleanTagText = tagText.match(/([^\s]*)=["'](.*?)["']|([\/?\w\-\:]+)/g);
+        var cleanTagText = tagText.match(/([^\s]*)=('([^']*?)'|"([^"]*?)")|([\/?\w\-\:]+)/g);
 
         var tag = {
             name: cleanTagText.shift(),
@@ -60,28 +60,27 @@ module.exports = class {
             if (attributeKeyVal.length < 2) {
                 return;
             }
-
-            tag.attributes[attributeKeyVal[0]] = typeof attributeKeyVal[1] === 'string' ? (attributeKeyVal[1].replace(/"/g, '').replace(/'/g, '').trim()) : attributeKeyVal[1];
+            tag.attributes[attributeKeyVal[0]] = 'string' === typeof attributeKeyVal[1] ? (attributeKeyVal[1].replace(/^"/g, '').replace(/^'/g, '').replace(/"$/g, '').replace(/'$/g, '').trim()) : attributeKeyVal[1];
         });
-        
+
         return tag;
     }
-    
+
     _parseValue(tagValue) {
         if (tagValue.indexOf('CDATA') < 0) {
             return tagValue.trim();
         }
-        
+
         return tagValue.substring(tagValue.lastIndexOf('[') + 1, tagValue.indexOf(']'));
     }
-    
+
     _convertTagsArrayToTree(xml) {
         var xmlTree = [];
-        
+
         if (xml.length == 0) {
             return xmlTree;
         }
-        
+
         var tag = xml.shift();
 
         if (tag.value.indexOf('</') > -1 || tag.name.match(/\/$/)) {
@@ -89,25 +88,25 @@ module.exports = class {
             tag.value = tag.value.substring(0, tag.value.indexOf('</'));
             xmlTree.push(tag);
             xmlTree = xmlTree.concat(this._convertTagsArrayToTree(xml));
-            
+
             return xmlTree;
         }
-        
+
         if (tag.name.indexOf('/') == 0) {
             return xmlTree;
         }
-        
+
         xmlTree.push(tag);
         tag.children = this._convertTagsArrayToTree(xml);
         xmlTree = xmlTree.concat(this._convertTagsArrayToTree(xml));
-        
+
         return xmlTree;
     }
-    
+
     _toString(xml) {
         var xmlText = this._convertTagToText(xml);
 
-        
+
         if (xml.children.length > 0) {
             xml.children.map(child => {
                 xmlText += this._toString(child);
@@ -115,18 +114,18 @@ module.exports = class {
 
             xmlText += '</' + xml.name + '>';
         }
-        
+
         return xmlText;
     }
-    
+
     _convertTagToText(tag) {
         var tagText = '<' + tag.name;
         var attributesText = [];
-        
+
         for (var attribute in tag.attributes) {
             tagText += ' ' + attribute + '="' + tag.attributes[attribute] + '"';
         }
-        
+
         if (tag.value.length > 0) {
             tagText += '>' + tag.value + '</' + tag.name + '>';
         } else {
@@ -136,7 +135,7 @@ module.exports = class {
         if (tag.children.length === 0) {
             tagText += '</' + tag.name + '>';
         }
-        
+
         return tagText;
     }
 


### PR DESCRIPTION
Example of xml string:

    <example name="o'really"></example>

Old parsing:

    Object {
      "attributes": Object {
        "name": "o",
      },
      "children": Array [],
      "getElementsByTagName": [Function _getElementsByTagName],
      "name": "example",
      "value": "",
    }

With this PR:

    Object {
      "attributes": Object {
        "name": "o'really",
      },
      "children": Array [],
      "getElementsByTagName": [Function _getElementsByTagName],
      "name": "example",
      "value": "",
    }

I am a bit unsure about the `splice` replacing `replace`. I don't understand the need for a full replace in the first place, I think this is enough.