### PR TITLE
Dev/fix recursion depth

### DIFF
--- a/xmlParser.js
+++ b/xmlParser.js
@@ -103,11 +103,7 @@ module.exports = class {
     _convertTagsArrayToTree(xml) {
         var xmlTree = [];
 
-        while(true) {
-            if (xml.length == 0) {
-                return xmlTree;
-            }
-
+        while(xml.length > 0) {
             var tag = xml.shift();
 
             if (tag.value.indexOf('</') > -1 || tag.name.match(/\/$/)) {
@@ -118,13 +114,14 @@ module.exports = class {
             }
 
             if (tag.name.indexOf('/') == 0) {
-                return xmlTree;
+                break;
             }
 
             xmlTree.push(tag);
             tag.children = this._convertTagsArrayToTree(xml);
             tag.value = decodeURIComponent(tag.value.trim());
         }
+        return xmlTree;
     }
 
     _toString(xml) {

--- a/xmlParser.js
+++ b/xmlParser.js
@@ -103,31 +103,28 @@ module.exports = class {
     _convertTagsArrayToTree(xml) {
         var xmlTree = [];
 
-        if (xml.length == 0) {
-            return xmlTree;
-        }
+        while(true) {
+            if (xml.length == 0) {
+                return xmlTree;
+            }
 
-        var tag = xml.shift();
+            var tag = xml.shift();
 
-        if (tag.value.indexOf('</') > -1 || tag.name.match(/\/$/)) {
-            tag.name = tag.name.replace(/\/$/, '').trim();
-            tag.value = tag.value.substring(0, tag.value.indexOf('</')).trim();
+            if (tag.value.indexOf('</') > -1 || tag.name.match(/\/$/)) {
+                tag.name = tag.name.replace(/\/$/, '').trim();
+                tag.value = tag.value.substring(0, tag.value.indexOf('</')).trim();
+                xmlTree.push(tag);
+                continue;
+            }
+
+            if (tag.name.indexOf('/') == 0) {
+                return xmlTree;
+            }
+
             xmlTree.push(tag);
-            xmlTree = xmlTree.concat(this._convertTagsArrayToTree(xml));
-
-            return xmlTree;
+            tag.children = this._convertTagsArrayToTree(xml);
+            tag.value = decodeURIComponent(tag.value.trim());
         }
-
-        if (tag.name.indexOf('/') == 0) {
-            return xmlTree;
-        }
-
-        xmlTree.push(tag);
-        tag.children = this._convertTagsArrayToTree(xml);
-        tag.value = decodeURIComponent(tag.value.trim());
-        xmlTree = xmlTree.concat(this._convertTagsArrayToTree(xml));
-
-        return xmlTree;
     }
 
     _toString(xml) {


### PR DESCRIPTION
Fixes #31 

Converted tail recursion into loop. This allows for parsing long xml files. The only limitation that remains is parsing a high level of embedded children. This could also be resolved by introducing a stack into the function, but seems to be not as typical and critical as long flat files.